### PR TITLE
Fix for issue #89

### DIFF
--- a/charts/deploy/templates/grafana-thanos-datasource.yaml
+++ b/charts/deploy/templates/grafana-thanos-datasource.yaml
@@ -16,5 +16,9 @@ spec:
       name: "prometheus"
       orgId: 1
       type: "prometheus"
+      {{- if .Values.bucket_access_point }}
       url: "https://thanos-pelorus.{{ .Release.Namespace }}.svc:9092"
+      {{- else }}
+      url: "https://prometheus-pelorus.{{ .Release.Namespace }}.svc:9091"
+      {{- end }}
       version: 1


### PR DESCRIPTION
If `bucket_access_point` isn't specified, then Pelorus defaults to no LTS and uses the legacy Prometheus service endpoint.  

resolves: #89 