### PR TITLE
Support custom ca

### DIFF
--- a/charts/deploy/templates/cluster-ca-bundle-configmap.yaml
+++ b/charts/deploy/templates/cluster-ca-bundle-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.custom_ca }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6,3 +7,4 @@ metadata:
     config.openshift.io/inject-trusted-cabundle: true
   name: cluster-ca-bundle
 data:
+{{- end }}

--- a/charts/deploy/templates/cluster-ca-bundle-configmap.yaml
+++ b/charts/deploy/templates/cluster-ca-bundle-configmap.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  annotations:
-    config.openshift.io/inject-trusted-cabundle: true
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
   name: cluster-ca-bundle
-data:
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/deploy/templates/cluster-ca-bundle-configmap.yaml
+++ b/charts/deploy/templates/cluster-ca-bundle-configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    config.openshift.io/inject-trusted-cabundle: true
+  name: cluster-ca-bundle
+data:

--- a/charts/deploy/templates/grafana.yaml
+++ b/charts/deploy/templates/grafana.yaml
@@ -16,36 +16,39 @@ spec:
     auth.anonymous:
       enabled: True
   containers:
-    - args:
-        - '-provider=openshift'
-        - '-pass-basic-auth=false'
-        - '-https-address=:9091'
-        - '-http-address='
-        - '-email-domain=*'
-        - '-upstream=http://localhost:3000'
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
-        - '-tls-cert=/etc/tls/private/tls.crt'
-        - '-tls-key=/etc/tls/private/tls.key'
-        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
-        - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
-        - '-openshift-service-account=grafana-serviceaccount'
-        - '-openshift-ca=/etc/pki/tls/cert.pem'
-        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-        - '-skip-auth-regex=^/metrics'
-      image: 'quay.io/openshift/origin-oauth-proxy:4.2'
-      name: grafana-proxy
-      ports:
-        - containerPort: 9091
-          name: grafana-proxy
-      resources: {}
-      volumeMounts:
-        - mountPath: /etc/tls/private
-          name: secret-grafana-k8s-tls
-          readOnly: false
-        - mountPath: /etc/proxy/secrets
-          name: secret-grafana-k8s-proxy
-          readOnly: false
+  - args:
+    - '-provider=openshift'
+    - '-pass-basic-auth=false'
+    - '-https-address=:9091'
+    - '-http-address='
+    - '-email-domain=*'
+    - '-upstream=http://localhost:3000'
+    - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+    - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+    - '-tls-cert=/etc/tls/private/tls.crt'
+    - '-tls-key=/etc/tls/private/tls.key'
+    - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+    - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
+    - '-openshift-service-account=grafana-serviceaccount'
+    - '-openshift-ca=/etc/pki/tls/cert.pem'
+    - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+    - '-openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt'
+    - '-skip-auth-regex=^/metrics'
+    image: 'quay.io/openshift/origin-oauth-proxy:4.2'
+    name: grafana-proxy
+    ports:
+      - containerPort: 9091
+        name: grafana-proxy
+    resources: {}
+    volumeMounts:
+      - mountPath: /etc/tls/private
+        name: secret-grafana-k8s-tls
+        readOnly: false
+      - mountPath: /etc/proxy/secrets
+        name: secret-grafana-k8s-proxy
+        readOnly: false
+  configMaps:
+  - cluster-ca-bundle
   secrets:
     - grafana-k8s-tls
     - grafana-k8s-proxy

--- a/charts/deploy/templates/grafana.yaml
+++ b/charts/deploy/templates/grafana.yaml
@@ -33,7 +33,7 @@ spec:
     - '-openshift-ca=/etc/pki/tls/cert.pem'
     - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 {{- if .Values.custom_ca }}
-    - -openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt
+    - -openshift-ca=/etc/prometheus/configmaps/cluster-ca-bundle/ca-bundle.crt
 {{- end}}
     - '-skip-auth-regex=^/metrics'
     image: 'quay.io/openshift/origin-oauth-proxy:4.2'
@@ -49,6 +49,9 @@ spec:
       - mountPath: /etc/proxy/secrets
         name: secret-grafana-k8s-proxy
         readOnly: false
+      - name: configmap-cluster-ca-bundle
+        readOnly: true
+        mountPath: /etc/prometheus/configmaps/cluster-ca-bundle
 {{- if .Values.custom_ca }}
   configMaps:
     - cluster-ca-bundle

--- a/charts/deploy/templates/grafana.yaml
+++ b/charts/deploy/templates/grafana.yaml
@@ -32,7 +32,9 @@ spec:
     - '-openshift-service-account=grafana-serviceaccount'
     - '-openshift-ca=/etc/pki/tls/cert.pem'
     - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-    - '-openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt'
+{{- if .Values.custom_ca }}
+    - -openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt
+{{- end}}
     - '-skip-auth-regex=^/metrics'
     image: 'quay.io/openshift/origin-oauth-proxy:4.2'
     name: grafana-proxy
@@ -47,8 +49,10 @@ spec:
       - mountPath: /etc/proxy/secrets
         name: secret-grafana-k8s-proxy
         readOnly: false
+{{- if .Values.custom_ca }}
   configMaps:
-  - cluster-ca-bundle
+    - cluster-ca-bundle
+{{- end }}
   secrets:
     - grafana-k8s-tls
     - grafana-k8s-proxy

--- a/charts/deploy/templates/prometheus-cr.yaml
+++ b/charts/deploy/templates/prometheus-cr.yaml
@@ -46,7 +46,7 @@ spec:
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 {{- if .Values.custom_ca }}
-    - -openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt
+    - -openshift-ca=/etc/prometheus/configmaps/cluster-ca-bundle/ca-bundle.crt
 {{- end}}
     - -skip-auth-regex=^/metrics
     image: registry.redhat.io/openshift3/oauth-proxy:v3.11
@@ -66,4 +66,8 @@ spec:
       name: secret-prometheus-pelorus-tls
     - mountPath: /etc/proxy/htpasswd
       name: secret-prometheus-pelorus-htpasswd
+    - name: configmap-cluster-ca-bundle
+      readOnly: true
+      mountPath: /etc/prometheus/configmaps/cluster-ca-bundle
+
 

--- a/charts/deploy/templates/prometheus-cr.yaml
+++ b/charts/deploy/templates/prometheus-cr.yaml
@@ -21,8 +21,10 @@ spec:
   additionalScrapeConfigs:
     name: additional-scrape-configs
     key: prometheus-additional.yml
+{{- if .Values.custom_ca }}
   configMaps:
     - cluster-ca-bundle
+{{- end }}
   secrets:
     - prometheus-pelorus-tls
     - prometheus-pelorus-htpasswd
@@ -43,7 +45,9 @@ spec:
     - -cookie-secret=bacon
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+{{- if .Values.custom_ca }}
     - -openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt
+{{- end}}
     - -skip-auth-regex=^/metrics
     image: registry.redhat.io/openshift3/oauth-proxy:v3.11
     name: prometheus-proxy

--- a/charts/deploy/templates/prometheus-cr.yaml
+++ b/charts/deploy/templates/prometheus-cr.yaml
@@ -21,6 +21,8 @@ spec:
   additionalScrapeConfigs:
     name: additional-scrape-configs
     key: prometheus-additional.yml
+  configMaps:
+    - cluster-ca-bundle
   secrets:
     - prometheus-pelorus-tls
     - prometheus-pelorus-htpasswd
@@ -41,6 +43,7 @@ spec:
     - -cookie-secret=bacon
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    - -openshift-ca=/etc/configmap/trusted-ca-bundle/ca-bundle.crt
     - -skip-auth-regex=^/metrics
     image: registry.redhat.io/openshift3/oauth-proxy:v3.11
     name: prometheus-proxy

--- a/charts/deploy/values.yaml
+++ b/charts/deploy/values.yaml
@@ -6,6 +6,9 @@ openshift_prometheus_htpasswd_auth: changeme
 openshift_prometheus_basic_auth_pass: changeme
 extra_prometheus_hosts:
 
+# Uncomment this if your cluster serves privately signed certificates
+# custom_ca: true
+
 deployment:
   labels:
     app.kubernetes.io/component: prometheus

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,5 +1,20 @@
 # Configuration
 
+## Configuring The Pelorus Stack
+
+The Pelorus stack (Prometheus, Grafana, Thanos, etc.) can be configured by changing the `values.yaml` file that is passed to helm. The recommended practice is to make a copy of the one [provided in this repo](/charts/)deploy/values.yaml), and store in in your own configuration repo for safe keeping, and updating. Once established, you can make configuration changes by updating your `values.yaml` and applying the changes like so:
+
+```
+./runhelm.sh --values=myclusterconfigs/pelorus/values.yaml
+```
+
+The following configurations may be made through the `values.yaml` file:
+
+| Variable | Required | Explanation | Default Value |
+|---|---|---|---|
+| `custom_ca` | no | Whether or not the cluster serves custom signed certificates for ingress (e.g. router certs). If `true` we will load the custom via the [certificate injection method](https://docs.openshift.com/container-platform/4.4/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki)  | `false`  |
+| `extra_prometheus_hosts` | no | Configures additional prometheus instances for a multi-cluster setup. See [Deploying across multple clusters](/docs/Install.md#deploying-across-multiple-clusters) for details. | Nil |
+
 ## Configuring Exporters
     
 ### Commit Time Exporter

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -5,7 +5,7 @@
 The Pelorus stack (Prometheus, Grafana, Thanos, etc.) can be configured by changing the `values.yaml` file that is passed to helm. The recommended practice is to make a copy of the one [provided in this repo](/charts/)deploy/values.yaml), and store in in your own configuration repo for safe keeping, and updating. Once established, you can make configuration changes by updating your `values.yaml` and applying the changes like so:
 
 ```
-./runhelm.sh --values=myclusterconfigs/pelorus/values.yaml
+./runhelm.sh -v myclusterconfigs/pelorus/values.yaml
 ```
 
 The following configurations may be made through the `values.yaml` file:

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -48,7 +48,7 @@ See the [Configuration Guide](/docs/Configuration.md) for more information on ex
 
 ## Customizing Pelorus
 
-The following sections describe the supported customizations that can be made to a Pelorus deployment.
+See [Configuring the Pelorus Stack](/docs/Configuration.md) for a full readout of all possible configuration items. The following sections describe the  most common supported customizations that can be made to a Pelorus deployment.
 
 ### Configure Long Term Storage
 


### PR DESCRIPTION
This PR supports configuring Pelorus to use a custom CA.

This can be tested on a cluster with a privately signed wildcard certificate by setting `custom_ca: true` in the values.yaml for the deploy chart. (see new `/docs/Configuration.md` for specifics). 

resolve #91 