### PR TITLE
Resolve several outstanding issues with thanos component

### DIFF
--- a/charts/deploy/templates/grafana.yaml
+++ b/charts/deploy/templates/grafana.yaml
@@ -49,10 +49,10 @@ spec:
       - mountPath: /etc/proxy/secrets
         name: secret-grafana-k8s-proxy
         readOnly: false
+{{- if .Values.custom_ca }}
       - name: configmap-cluster-ca-bundle
         readOnly: true
         mountPath: /etc/prometheus/configmaps/cluster-ca-bundle
-{{- if .Values.custom_ca }}
   configMaps:
     - cluster-ca-bundle
 {{- end }}

--- a/charts/deploy/templates/prometheus-cr.yaml
+++ b/charts/deploy/templates/prometheus-cr.yaml
@@ -14,6 +14,7 @@ spec:
       name: thanos-objstore-config
   {{- end }}
   replicas: 2
+  replicaExternalLabelName: ""
   ruleNamespaceSelector: {}
   ruleSelector: {}
   serviceAccountName: pelorus-prometheus
@@ -66,8 +67,10 @@ spec:
       name: secret-prometheus-pelorus-tls
     - mountPath: /etc/proxy/htpasswd
       name: secret-prometheus-pelorus-htpasswd
+{{- if .Values.custom_ca }}
     - name: configmap-cluster-ca-bundle
       readOnly: true
       mountPath: /etc/prometheus/configmaps/cluster-ca-bundle
+{{- end }}
 
 

--- a/charts/deploy/templates/thanos-query.yml
+++ b/charts/deploy/templates/thanos-query.yml
@@ -27,6 +27,12 @@ spec:
       - name: secret-prometheus-pelorus-htpasswd
         secret:
           secretName: prometheus-pelorus-htpasswd
+  {{- if .Values.custom_ca }}
+      - name: configmap-cluster-ca-bundle
+        configMap:
+          name: cluster-ca-bundle
+          defaultMode: 420
+  {{- end }}
       containers:
       - name: thanos-query
         image: quay.io/thanos/thanos:v0.8.1
@@ -60,6 +66,9 @@ spec:
         - -cookie-secret=bacon
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  {{- if .Values.custom_ca }}
+        - -openshift-ca=/etc/prometheus/configmaps/cluster-ca-bundle/ca-bundle.crt
+  {{- end}}
         - -skip-auth-regex=^/metrics
         image: registry.redhat.io/openshift3/oauth-proxy:v3.11
         name: thanos-proxy
@@ -72,4 +81,9 @@ spec:
           name: secret-prometheus-pelorus-tls
         - mountPath: /etc/proxy/htpasswd
           name: secret-prometheus-pelorus-htpasswd
+  {{- if .Values.custom_ca }}
+        - name: configmap-cluster-ca-bundle
+          readOnly: true
+          mountPath: /etc/prometheus/configmaps/cluster-ca-bundle
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR does the following

* adds support for custom CAs in the thanos component (we missed this when we resolved #91 )
* resolves #105

To test:

1. Deploy pelorus with and without thanos. Make sure that the dashboard is working.
2. Configure a custom wildcard cert, and ensure you can still log into thanos.