### PR TITLE
Add production label to deploytime metric

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -69,6 +69,7 @@ This exporter supports several configuration options, passed via environment var
 | Variable | Required | Explanation | Default Value |
 |---|---|---|---|
 | `APP_LABEL` | no | Changes the label key used to identify applications  | `app.kubernetes.io/name`  |
+| `PROD_LABEL` | no | Changes the label key used to identify namespaces that are considered production environments. | unset; matches all namespaces |
 | `NAMESPACES` | no | Restricts the set of namespaces from which metrics will be collected. ex: `myapp-ns-dev,otherapp-ci` | unset; scans all namespaces |
     
 ### Failure Time Exporter

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -54,7 +54,8 @@ def generate_metrics(namespaces):
     if not namespaces:
         print("No namespaces specified, watching all namespaces\n")
         v1_namespaces = dyn_client.resources.get(api_version='v1', kind='Namespace')
-        namespaces = [namespace.metadata.name for namespace in v1_namespaces.get().items]
+        namespaces = [namespace.metadata.name for namespace in v1_namespaces.get(
+            label_selector=pelorus.get_prod_label()).items]
     else:
         print("Watching namespaces: %s\n" % (namespaces))
 

--- a/exporters/pelorus.py
+++ b/exporters/pelorus.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from kubernetes import config
 
 DEFAULT_APP_LABEL = 'app.kubernetes.io/name'
+DEFAULT_PROD_LABEL = ''
 DEFAULT_LOG_LEVEL = 'INFO'
 
 loglevel = os.getenv('LOG_LEVEL', DEFAULT_LOG_LEVEL)
@@ -38,6 +39,9 @@ def convert_date_time_to_timestamp(date_time):
 
 def get_app_label():
     return os.getenv('APP_LABEL', DEFAULT_APP_LABEL)
+
+def get_prod_label():
+    return os.getenv('PROD_LABEL', DEFAULT_PROD_LABEL)
 
 
 def check_required_config(vars):

--- a/exporters/pelorus.py
+++ b/exporters/pelorus.py
@@ -40,6 +40,7 @@ def convert_date_time_to_timestamp(date_time):
 def get_app_label():
     return os.getenv('APP_LABEL', DEFAULT_APP_LABEL)
 
+
 def get_prod_label():
     return os.getenv('PROD_LABEL', DEFAULT_PROD_LABEL)
 


### PR DESCRIPTION
This PR add the ability for an admin to set a label, such as `env=production` as the search criteria for namespaces in scope for tracking deployment metrics.

To Test:

1. Spin up deploytime exporter locally. Behavior should be same as before.
2. Set `PROD_LABEL="env=production"` and spin up exporter again. Initially you should see no metrics captured. 
3. Label a relevant namespace like `oc label ns/basic-nginx-prod env=production`, and then `curl localhost:8080` to trigger again, and you should see metrics from that namespace.