### PR TITLE
Process ReplicaSets

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: v1.2.1-rc-18-gb2692e1
+version: v1.2.1-rc-19-g00bb951
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: v1.2.1-rc-19-g00bb951
+version: 1.2.1+rc.20.g3854086
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: v1.2.1-rc-3-g4c285d1
+version: v1.2.1-3-g9a7b326 
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.1+18.gf87cbfd
+version: v1.2.1-rc-18-gb2692e1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.1+rc.20.g3854086
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.16.0
+appVersion: 1.2.1+20.gb9cac53

--- a/charts/pelorus/charts/exporters/templates/rbac.yaml
+++ b/charts/pelorus/charts/exporters/templates/rbac.yaml
@@ -21,6 +21,18 @@ rules:
   verbs:
   - list
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - list
+- apiGroups:
   - build.openshift.io
   resources:
   - builds

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -65,19 +65,19 @@ def generate_metrics(namespaces):
         # Process ReplicationControllers for DeploymentConfigs
         v1_replicationcontrollers = dyn_client.resources.get(api_version='v1', kind='ReplicationController')
         replicationcontrollers = v1_replicationcontrollers.get(namespace=namespace,
-                                                                label_selector=pelorus.get_app_label())
+            label_selector=pelorus.get_app_label())
         replicas = replicationcontrollers.items
 
         # Process ReplicaSets from apps/v1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='apps/v1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
-                                                    label_selector=pelorus.get_app_label())
+            label_selector=pelorus.get_app_label())
         replicas = replicas + replicationsets.items
 
         # Process ReplicaSets from extentions/v1beta1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='extensions/v1beta1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
-                                                    label_selector=pelorus.get_app_label())
+            label_selector=pelorus.get_app_label())
         replicas = replicas + replicationsets.items
 
         for rc in replicas:

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -65,19 +65,19 @@ def generate_metrics(namespaces):
         # Process ReplicationControllers for DeploymentConfigs
         v1_replicationcontrollers = dyn_client.resources.get(api_version='v1', kind='ReplicationController')
         replicationcontrollers = v1_replicationcontrollers.get(namespace=namespace,
-            label_selector=pelorus.get_app_label())
+                                                               label_selector=pelorus.get_app_label())
         replicas = replicationcontrollers.items
 
         # Process ReplicaSets from apps/v1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='apps/v1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
-            label_selector=pelorus.get_app_label())
+                                                 label_selector=pelorus.get_app_label())
         replicas = replicas + replicationsets.items
 
         # Process ReplicaSets from extentions/v1beta1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='extensions/v1beta1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
-            label_selector=pelorus.get_app_label())
+                                                 label_selector=pelorus.get_app_label())
         replicas = replicas + replicationsets.items
 
         for rc in replicas:

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -65,24 +65,24 @@ def generate_metrics(namespaces):
         # Process ReplicationControllers for DeploymentConfigs
         v1_replicationcontrollers = dyn_client.resources.get(api_version='v1', kind='ReplicationController')
         replicationcontrollers = v1_replicationcontrollers.get(namespace=namespace,
-                                                               label_selector=pelorus.get_app_label())
+                                                                label_selector=pelorus.get_app_label())
         replicas = replicationcontrollers.items
 
         # Process ReplicaSets from apps/v1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='apps/v1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
-                                                               label_selector=pelorus.get_app_label())
+                                                    label_selector=pelorus.get_app_label())
         replicas = replicas + replicationsets.items
 
         # Process ReplicaSets from extentions/v1beta1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='extensions/v1beta1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
-                                                               label_selector=pelorus.get_app_label())
+                                                    label_selector=pelorus.get_app_label())
         replicas = replicas + replicationsets.items
 
         for rc in replicas:
             images = [image_sha(c.image) for c in rc.spec.template.spec.containers]
-            print ("IMAGE" + str(images))
+            print("IMAGE" + str(images))
 
             # Since a commit will be built into a particular image and there could be multiple
             # containers (images) per pod, we will push one metric per image/container in the

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -60,30 +60,29 @@ def generate_metrics(namespaces):
         print("Watching namespaces: %s\n" % (namespaces))
 
     for namespace in namespaces:
+        replicas = []
+
+        # Process ReplicationControllers for DeploymentConfigs
         v1_replicationcontrollers = dyn_client.resources.get(api_version='v1', kind='ReplicationController')
         replicationcontrollers = v1_replicationcontrollers.get(namespace=namespace,
                                                                label_selector=pelorus.get_app_label())
+        replicas = replicationcontrollers.items
 
-        for rc in replicationcontrollers.items:
-            images = [image_sha(c.image) for c in rc.spec.template.spec.containers]
-
-            # Since a commit will be built into a particular image and there could be multiple
-            # containers (images) per pod, we will push one metric per image/container in the
-            # pod template
-            for i in images:
-                if i is not None:
-                    metric = DeployTimeMetric(rc.metadata.name, namespace)
-                    metric.labels = rc.metadata.labels
-                    metric.deploy_time = rc.metadata.creationTimestamp
-                    metric.image_sha = i
-                    metrics.append(metric)
-
+        # Process ReplicaSets from apps/v1 api version for Deployments
         v1_replicationsets = dyn_client.resources.get(api_version='apps/v1', kind='ReplicaSet')
         replicationsets = v1_replicationsets.get(namespace=namespace,
                                                                label_selector=pelorus.get_app_label())
+        replicas = replicas + replicationsets.items
 
-        for rc in replicationsets.items:
+        # Process ReplicaSets from extentions/v1beta1 api version for Deployments
+        v1_replicationsets = dyn_client.resources.get(api_version='extensions/v1beta1', kind='ReplicaSet')
+        replicationsets = v1_replicationsets.get(namespace=namespace,
+                                                               label_selector=pelorus.get_app_label())
+        replicas = replicas + replicationsets.items
+
+        for rc in replicas:
             images = [image_sha(c.image) for c in rc.spec.template.spec.containers]
+            print ("IMAGE" + str(images))
 
             # Since a commit will be built into a particular image and there could be multiple
             # containers (images) per pod, we will push one metric per image/container in the
@@ -95,7 +94,6 @@ def generate_metrics(namespaces):
                     metric.deploy_time = rc.metadata.creationTimestamp
                     metric.image_sha = i
                     metrics.append(metric)
-
 
     return metrics
 


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR
This will process ReplicaSets which are used for deployment type configurations.

## Linked Issues?

resolves #165 


## Testing Instructions

Run the deploytime exporter and verify values for ReplicaSets which are related to Deployment configurations.

@redhat-cop/mdt
