### PR TITLE
Fix rolebinding reference for exporter role

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: v1.2.1-rc-3-g4c285d1
+version: v1.2.1-4-gd1cf1da
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/charts/exporters/templates/rbac.yaml
+++ b/charts/pelorus/charts/exporters/templates/rbac.yaml
@@ -38,7 +38,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pelorus-exporter
+  name: pelorus-exporter-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: pelorus-exporter


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

#170 called out a bug where we didn't properly clean up a static reference to the `pelorus-exporter` clusterrole after we renamed the role to `pelorus-exporter-{{ .Release.Namespace }}`. We didn't catch it because we are testing in "dirty clusters" where the role still exists.

## Linked Issues?

resolves #170 

## Testing Instructions

1. Make sure that you clean out any previously applied role with `oc delete clusterrole pelorus-exporter`.
2. Follow install doc.

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
