### PR TITLE
Set up grafana to automatically take snapshots of SPD global dashboar…

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: deploy
+name: pelorus
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.7
+version: 1.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/templates/dashboard-sdp-byapp.yaml
+++ b/charts/pelorus/templates/dashboard-sdp-byapp.yaml
@@ -1119,7 +1119,7 @@ spec:
     "refresh": false,
     "schemaVersion": 21,
     "style": "dark",
-    "tags": [],
+    "tags": ["team", "software-delivery-performance"],
     "templating": {
         "list": [
         {

--- a/charts/pelorus/templates/dashboard-sdp.yaml
+++ b/charts/pelorus/templates/dashboard-sdp.yaml
@@ -1643,8 +1643,8 @@ spec:
     ],
     "refresh": "30s",
     "schemaVersion": 21,
-    "style": "dark",
-    "tags": [],
+    "style": "light",
+    "tags": ["global", "software-delivery-performance"],
     "templating": {
         "list": []
     },
@@ -1679,6 +1679,6 @@ spec:
     },
     "timezone": "",
     "title": "Software Delivery Performance",
-    "uid": "eee3570b25fea8ce185d751082908fff",
-    "version": 2
+    "uid": "sdp-global",
+    "version": 3
     }

--- a/charts/pelorus/templates/dashboard-snapshot-cronjob.yaml
+++ b/charts/pelorus/templates/dashboard-snapshot-cronjob.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dashboard-snapshots
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dashboard-snapshots
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dashboard-snapshots
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dashboard-snapshots
+subjects:
+- kind: ServiceAccount
+  name: dashboard-snapshots
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: dashboard-snapshots
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          activeDeadlineSeconds: 500
+          containers:
+          - command:
+            - /bin/bash
+            - -c
+            - |
+              # Install jq
+              curl -so jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+              chmod +x jq
+
+              # Grab the information we need to make initial api calls to grafana
+              apikey=$(oc get secrets grafana-apikey -o jsonpath='{.data.key}' | base64 -d)
+              grafana_url=$(oc get route grafana-route -o jsonpath='{.spec.host}')
+
+              # Get the dashboard we want to snapshot
+              dashboard_search=$(curl -s -k -H "Authorization: Bearer $apikey" "https://${grafana_url}/api/search?query=Software&tag=global&type=dash-db")
+              dash_uid=$(echo $dashboard_search | ./jq -r .[0].uid)
+              dashboard_data=$(curl -s -k -H "Authorization: Bearer $apikey" "https://${grafana_url}/api/dashboards/uid/${dash_uid}")
+              dashboard="{ \"dashboard\": $(echo $dashboard_data | ./jq .dashboard) }"
+              snapshot=$(curl -s -k -X POST -H "Authorization: Bearer $apikey" -H "Content-Type: application/json" -d "${dashboard}" "https://${grafana_url}/api/snapshots")
+              snap_key=$(echo $snapshot | ./jq -r .key)
+
+              echo "New Snapshot: https://${grafana_url}/dashboard/snapshot/${snap_key}"
+            image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
+            name: dashboard-snapshots
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          serviceAccount: dashboard-snapshots
+          serviceAccountName: dashboard-snapshots
+          terminationGracePeriodSeconds: 30
+  schedule: "{{ .Values.snapshot_schedule }}"
+  successfulJobsHistoryLimit: 2

--- a/charts/pelorus/templates/grafana-post-install-hook.yaml
+++ b/charts/pelorus/templates/grafana-post-install-hook.yaml
@@ -83,18 +83,33 @@ spec:
               chmod +x jq
 
               # Grab the information we need to make initial api calls to grafana
-              admin_pw=$(oc get secrets grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d)
-              grafana_url=$(oc get route grafana-route -o jsonpath='{.spec.host}')
+              echo "Get grafana URL and Credentials"
+              secret=1
+              route=1
+              until [ $secret -eq 0 ] && [ $route -eq 0 ]; do
+                sleep 1
+                admin_pw=$(oc get secrets grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d)
+                secret=$?
+                grafana_url=$(oc get route grafana-route -o jsonpath='{.spec.host}')
+                route=$?
+              done
 
-              orgId=1
-              echo $orgId
+
+              # Wait until grafana api is up
+              echo "Wait for grafana to be up"
+              up=1
+              until [ $up -eq 0 ] && [ "$(echo $health | ./jq -r .database)" == "ok" ]; do
+                health=$(curl -s -k -X GET https://admin:${admin_pw}@${grafana_url}/api/health)
+                up=$?
+              done
 
               # Switch to the new org context
-              curl -s -k -X POST https://admin:${admin_pw}@${grafana_url}/api/user/using/${orgId}
+              orgId=1
+              curl -s -k -X POST https://admin:${admin_pw}@${grafana_url}/api/user/using/${orgId} || exit 1
 
               # Create the apikey we will use in the future
+              echo "Creating new api key"
               apikey=$(curl -s -k -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' https://admin:${admin_pw}@${grafana_url}/api/auth/keys)
-              echo "$apikey"
               message=$(echo $apikey | ./jq -r .message)
               if [ "${message}" == "API Key Organization ID And Name Must Be Unique" ]; then
                 # Key already exists and we can't fetch the key. Delete the key and recreate.
@@ -105,17 +120,21 @@ spec:
               fi
               apikey_name=$(echo $apikey | ./jq -r .name)
               apikey_key=$(echo $apikey | ./jq -r .key)
-              echo $apikey_name
 
               # Save apikey as a secret
-              echo "apiVersion: v1
-              stringData:
-                name: $apikey_name
-                key: $apikey_key
-              kind: Secret
-              metadata:
-                name: grafana-apikey
-              type: Opaque" | oc apply -f- 
+              echo "{
+                \"apiVersion\": \"v1\",
+                \"stringData\": {
+                    \"name\": \"${apikey_name}\",
+                    \"key\": \"${apikey_key}\"
+                },
+                \"kind\": \"Secret\",
+                \"metadata\": {
+                    \"name\": \"grafana-apikey\",
+                    \"type\": \"Opaque\"
+                }
+              }" | oc apply -f- 
+              echo "API Key saved to secret."
 
           imagePullPolicy: Always
           name: main

--- a/charts/pelorus/templates/grafana-post-install-hook.yaml
+++ b/charts/pelorus/templates/grafana-post-install-hook.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-api
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: grafana-api
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - patch
+  - update
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grafana-api
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: grafana-api
+subjects:
+- kind: ServiceAccount
+  name: grafana-api
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grafana-create-apikey
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+        - image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
+          command:
+            - /bin/bash
+            - -c
+            - |
+              # Install jq
+              curl -o jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+              chmod +x jq
+
+              # Grab the information we need to make initial api calls to grafana
+              admin_pw=$(oc get secrets grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d)
+              grafana_url=$(oc get route grafana-route -o jsonpath='{.spec.host}')
+
+              orgId=1
+              echo $orgId
+
+              # Switch to the new org context
+              curl -s -k -X POST https://admin:${admin_pw}@${grafana_url}/api/user/using/${orgId}
+
+              # Create the apikey we will use in the future
+              apikey=$(curl -s -k -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' https://admin:${admin_pw}@${grafana_url}/api/auth/keys)
+              echo "$apikey"
+              message=$(echo $apikey | ./jq -r .message)
+              if [ "${message}" == "API Key Organization ID And Name Must Be Unique" ]; then
+                # Key already exists and we can't fetch the key. Delete the key and recreate.
+                apikeys=$(curl -s -k https://admin:${admin_pw}@${grafana_url}/api/auth/keys)
+                apikeyId=$(echo $apikeys | ./jq '.[] | select(.name=="apikeycurl") | .id')
+                deletekey=$(curl -s -k -X DELETE -H "Content-Type: application/json" https://admin:${admin_pw}@${grafana_url}/api/auth/keys/${apikeyId})
+                apikey=$(curl -s -k -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' https://admin:${admin_pw}@${grafana_url}/api/auth/keys)
+              fi
+              apikey_name=$(echo $apikey | ./jq -r .name)
+              apikey_key=$(echo $apikey | ./jq -r .key)
+              echo $apikey_name
+
+              # Save apikey as a secret
+              echo "apiVersion: v1
+              stringData:
+                name: $apikey_name
+                key: $apikey_key
+              kind: Secret
+              metadata:
+                name: grafana-apikey
+              type: Opaque" | oc apply -f- 
+
+          imagePullPolicy: Always
+          name: main
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      serviceAccount: grafana-api
+      serviceAccountName: grafana-api
+      terminationGracePeriodSeconds: 30

--- a/charts/pelorus/templates/grafana.yaml
+++ b/charts/pelorus/templates/grafana.yaml
@@ -35,7 +35,7 @@ spec:
 {{- if .Values.custom_ca }}
     - -openshift-ca=/etc/prometheus/configmaps/cluster-ca-bundle/ca-bundle.crt
 {{- end}}
-    - '-skip-auth-regex=^/metrics'
+    - '-skip-auth-regex=^/metrics|^/dashboard/snapshot|^/public|^/api'
     image: 'quay.io/openshift/origin-oauth-proxy:4.2'
     name: grafana-proxy
     ports:

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -26,3 +26,5 @@ exporters:
       value: deploytime/app.py
     source_ref: master
     source_url: https://github.com/redhat-cop/pelorus.git
+
+snapshot_schedule: "@monthly"


### PR DESCRIPTION
…d on a schedule

## Describe the behavior changes introduced in this PR

This PR adds two jobs to the pelorus helm chart.

* The first jobs is a post-install/post-upgrade hook that creates an apikey in grafana and saves it as a secret
* The second job is a CronJob that uses the apikey to create snapshots in Grafana. Currently it only snapshots the global SDP dashboard.

Outstanding items:
* Currently the snapshot job just creates the snapshot and logs the URL in the job pod. Some further work will need to be done to make that URL more easily available.

## Linked Issues?

resolves #47 

## Testing Instructions

Deploy Pelorus, overloading the `snapshot_schedule` variable to something quick, like `*/2 * * * *`, then wait 2 minutes, and check that the cronjob runs. Check the pod logs, and copy the URL into the browser in incognito mode to ensure that an unauthenticated user can view the snapshot

@redhat-cop/mdt
