### PR TITLE
Adds Helm test for Grafana.

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.7
+version: 1.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.2+9.g2a623e0
+appVersion: 1.2.2+11.g6c91d8a

--- a/charts/pelorus/templates/tests/pelorus-grafana-test-job.yaml
+++ b/charts/pelorus/templates/tests/pelorus-grafana-test-job.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pelorus-grafana-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: pelorus-grafana-test
+    spec:
+      containers:
+      - name: grafana-dashboard-test
+        image: docker.io/dwdraju/alpine-curl-jq # TODO: decide  what image to use...
+        env:
+        - name: PELORUS_DASHBOARDS
+          value: "software-delivery-performance,software-delivery-performance-by-app"
+        - name: GRAFANA_HOSTNAME
+          value: "http://grafana-service:3000"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # Check if all the Pelorus Dashboards are defined in Grafana.
+          # Pelorus Dashboards should be provided by and env var.
+          # PELORUS_DASHBOARDS -> Comma separated list of dashboards. E.g: "software-delivery-performance,software-delivery-performance-by-app"
+
+          # If this file exists, then I am inside a Pod.
+          _K8s_SA_TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+          # Assuming here Pelorus means folderId=1 inside Grafana.
+          _GRAFANA_API_PELORUS_FOLDER="/api/search?folderIds=1&query=&starred=false"
+
+          echo -e "Checking Pelorus dashboards in Grafana.\n"
+
+          if [[ -f "${_K8s_SA_TOKEN_FILE}" ]]
+          then
+              echo -e "Executing tests inside a Kubernetes Pod.\n"
+              _POD_SA_TOKEN="$(cat "${_K8s_SA_TOKEN_FILE}")"
+
+          else
+              echo -e "Executing tests outside a Kubernetes Pod.\n"
+              _POD_SA_TOKEN=""
+          fi
+
+          # Composing vars
+          _GRAFANA_API_PELORUS_FOLDERS_URL="${GRAFANA_HOSTNAME}${_GRAFANA_API_PELORUS_FOLDER}"
+          # Show vars for debug purposes
+          echo -e "Pelorus folders URL in Grafana: $_GRAFANA_API_PELORUS_FOLDERS_URL \n"
+          echo -e "Pelorus dashboards: $PELORUS_DASHBOARDS \n"
+
+          # Get Grafana dashboards
+          _GRAFANA_DASHBOARDS=$(curl -k -v -s "${_GRAFANA_API_PELORUS_FOLDERS_URL}" |  jq -r '.[].uri')
+
+          # Test all Pelorus dashboards exists in Grafana.
+          echo -e "\nChecking Pelorus dashboards...\n"
+          for pd in ${PELORUS_DASHBOARDS//,/ }
+          do
+
+            FOUND="false"
+            echo -e "Checking Pelorus dashboard: $pd.\n"
+            for gd in ${_GRAFANA_DASHBOARDS}
+            do
+
+                 # Remove Grafana dashboard prefix: db/software-delivery-performance -> software-delivery-performance
+                 gd_name=${gd//db\//}
+                 if [[ "${gd_name}" == ${pd} ]]
+                 then
+                    echo -e "Pelorus dashboard present in Grafana: $pd.\n"
+                    FOUND="true"
+                 fi
+
+            done
+
+            if [[ "${FOUND}" == "false" ]]
+            then
+                echo -e "Pelorus dashboard not found in Grafana: $pd. Failing Tests!!\n"
+                exit -1
+            fi
+
+          done
+
+          echo -e "All Pelorus dashboards are present in Grafana. Test OK!!\n"
+          exit 0
+      restartPolicy: Never

--- a/charts/pelorus/templates/tests/pelorus-grafana-test-job.yaml
+++ b/charts/pelorus/templates/tests/pelorus-grafana-test-job.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: grafana-dashboard-test
-        image: docker.io/dwdraju/alpine-curl-jq # TODO: decide  what image to use...
+        image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
         env:
         - name: PELORUS_DASHBOARDS
           value: "software-delivery-performance,software-delivery-performance-by-app"
@@ -24,6 +24,10 @@ spec:
         - /bin/bash
         - -c
         - |
+          # Install jq. Not friendly with disconnected environments...
+          curl -so jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          chmod +x jq
+
           # Check if all the Pelorus Dashboards are defined in Grafana.
           # Pelorus Dashboards should be provided by and env var.
           # PELORUS_DASHBOARDS -> Comma separated list of dashboards. E.g: "software-delivery-performance,software-delivery-performance-by-app"
@@ -52,7 +56,7 @@ spec:
           echo -e "Pelorus dashboards: $PELORUS_DASHBOARDS \n"
 
           # Get Grafana dashboards
-          _GRAFANA_DASHBOARDS=$(curl -k -v -s "${_GRAFANA_API_PELORUS_FOLDERS_URL}" |  jq -r '.[].uri')
+          _GRAFANA_DASHBOARDS=$(curl -k -v -s "${_GRAFANA_API_PELORUS_FOLDERS_URL}" |  ./jq -r '.[].uri')
 
           # Test all Pelorus dashboards exists in Grafana.
           echo -e "\nChecking Pelorus dashboards...\n"


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

This PR adds a helm test hook in the form of a k8s job.
This job checks all the Prometheus targets are "UP".

To run the test once Pelorus has been deployed succesfully:
helm test pelorus

If this get merged, I would like to reactor testing documentation with this update, as it seems a bit disperse/hidden in the repo.

A couple of things to look into this PR:

The container image i am using is from docker, it requites curl and jq

## Linked Issues?

related to #https://github.com/redhat-cop/pelorus/issues/36

related to #https://github.com/redhat-cop/pelorus/pull/227

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
